### PR TITLE
build 3.10 for osx-arm

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -108,6 +108,11 @@ jobs:
         export CI=azure
         export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
         export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+        if [[ "${BUILD_REASON:-}" == "PullRequest" ]]; then
+          export IS_PR_BUILD="True"
+        else
+          export IS_PR_BUILD="False"
+        fi
         .scripts/run_docker_build.sh
     displayName: Run docker build
     env:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,6 +8,9 @@ jobs:
     vmImage: macOS-10.15
   strategy:
     matrix:
+      osx_64_cross_target_platformosx-arm64py_implcpythonversion3.10:
+        CONFIG: osx_64_cross_target_platformosx-arm64py_implcpythonversion3.10
+        UPLOAD_PACKAGES: 'True'
       osx_64_cross_target_platformosx-arm64py_implcpythonversion3.8:
         CONFIG: osx_64_cross_target_platformosx-arm64py_implcpythonversion3.8
         UPLOAD_PACKAGES: 'True'
@@ -38,6 +41,11 @@ jobs:
       export OSX_FORCE_SDK_DOWNLOAD="1"
       export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
       export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+      if [[ "${BUILD_REASON:-}" == "PullRequest" ]]; then
+        export IS_PR_BUILD="True"
+      else
+        export IS_PR_BUILD="False"
+      fi
       ./.scripts/run_osx_build.sh
     displayName: Run OSX build
     env:

--- a/.ci_support/osx_64_cross_target_platformosx-arm64py_implcpythonversion3.10.yaml
+++ b/.ci_support/osx_64_cross_target_platformosx-arm64py_implcpythonversion3.10.yaml
@@ -1,0 +1,19 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cross_target_platform:
+- osx-arm64
+macos_machine:
+- x86_64-apple-darwin13.4.0
+py_impl:
+- cpython
+target_platform:
+- osx-64
+version:
+- '3.10'
+zip_keys:
+- - version
+  - py_impl

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -25,7 +25,8 @@ conda-build:
  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
 
 CONDARC
-BUILD_CMD=build
+GET_BOA=boa
+BUILD_CMD=mambabuild
 
 conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip ${GET_BOA:-} -c conda-forge
 
@@ -37,8 +38,8 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
-if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
-     EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${HOST_PLATFORM}" != linux-* ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
 fi
 
 
@@ -66,7 +67,7 @@ else
 
     ( startgroup "Uploading packages" ) 2> /dev/null
 
-    if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+    if [[ "${UPLOAD_PACKAGES}" != "False" ]] && [[ "${IS_PR_BUILD}" == "False" ]]; then
         upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
     fi
 

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -75,12 +75,15 @@ fi
 ( startgroup "Start Docker" ) 2> /dev/null
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
+export IS_PR_BUILD="${IS_PR_BUILD:-False}"
+docker pull "${DOCKER_IMAGE}"
 docker run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
            -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \
+           -e IS_PR_BUILD \
            -e GIT_BRANCH \
            -e UPLOAD_ON_BRANCH \
            -e CI \
@@ -91,9 +94,9 @@ docker run ${DOCKER_RUN_ARGS} \
            -e BINSTAR_TOKEN \
            -e FEEDSTOCK_TOKEN \
            -e STAGING_BINSTAR_TOKEN \
-           $DOCKER_IMAGE \
+           "${DOCKER_IMAGE}" \
            bash \
-           /home/conda/feedstock_root/${PROVIDER_DIR}/build_steps.sh
+           "/home/conda/feedstock_root/${PROVIDER_DIR}/build_steps.sh"
 
 # verify that the end of the script was reached
 test -f "$DONE_CANARY"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -9,15 +9,17 @@ MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
 ( startgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
 
 MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
-MINIFORGE_FILE="Miniforge3-MacOSX-x86_64.sh"
+MINIFORGE_FILE="Miniforge3-MacOSX-$(uname -m).sh"
 curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
+rm -rf ${MINIFORGE_HOME}
 bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 
 ( endgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
 
 ( startgroup "Configuring conda" ) 2> /dev/null
 
-BUILD_CMD=build
+GET_BOA=boa
+BUILD_CMD=mambabuild
 
 source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
@@ -66,7 +68,7 @@ validate_recipe_outputs "${FEEDSTOCK_NAME}"
 
 ( startgroup "Uploading packages" ) 2> /dev/null
 
-if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+if [[ "${UPLOAD_PACKAGES}" != "False" ]] && [[ "${IS_PR_BUILD}" == "False" ]]; then
   upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}" ./ ./recipe ./.ci_support/${CONFIG}.yaml
 fi
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-About cross-python_linux-aarch64
-================================
+About cross-python_osx-arm64
+============================
 
 Home: https://github.com/conda-forge/cross-python-feedstock
 
@@ -167,6 +167,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_64_cross_target_platformosx-arm64py_implcpythonversion3.10</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10723&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cross-python-feedstock?branchName=master&jobName=osx&configuration=osx_64_cross_target_platformosx-arm64py_implcpythonversion3.10" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64_cross_target_platformosx-arm64py_implcpythonversion3.8</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=10723&branchName=master">
@@ -228,32 +235,29 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-cross--python_linux--64-green.svg)](https://anaconda.org/conda-forge/cross-python_linux-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/cross-python_linux-64.svg)](https://anaconda.org/conda-forge/cross-python_linux-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/cross-python_linux-64.svg)](https://anaconda.org/conda-forge/cross-python_linux-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/cross-python_linux-64.svg)](https://anaconda.org/conda-forge/cross-python_linux-64) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-cross--python_linux--aarch64-green.svg)](https://anaconda.org/conda-forge/cross-python_linux-aarch64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/cross-python_linux-aarch64.svg)](https://anaconda.org/conda-forge/cross-python_linux-aarch64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/cross-python_linux-aarch64.svg)](https://anaconda.org/conda-forge/cross-python_linux-aarch64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/cross-python_linux-aarch64.svg)](https://anaconda.org/conda-forge/cross-python_linux-aarch64) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-cross--python_linux--ppc64le-green.svg)](https://anaconda.org/conda-forge/cross-python_linux-ppc64le) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/cross-python_linux-ppc64le.svg)](https://anaconda.org/conda-forge/cross-python_linux-ppc64le) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/cross-python_linux-ppc64le.svg)](https://anaconda.org/conda-forge/cross-python_linux-ppc64le) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/cross-python_linux-ppc64le.svg)](https://anaconda.org/conda-forge/cross-python_linux-ppc64le) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-cross--python_osx--64-green.svg)](https://anaconda.org/conda-forge/cross-python_osx-64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/cross-python_osx-64.svg)](https://anaconda.org/conda-forge/cross-python_osx-64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/cross-python_osx-64.svg)](https://anaconda.org/conda-forge/cross-python_osx-64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/cross-python_osx-64.svg)](https://anaconda.org/conda-forge/cross-python_osx-64) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-cross--python_osx--arm64-green.svg)](https://anaconda.org/conda-forge/cross-python_osx-arm64) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/cross-python_osx-arm64.svg)](https://anaconda.org/conda-forge/cross-python_osx-arm64) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/cross-python_osx-arm64.svg)](https://anaconda.org/conda-forge/cross-python_osx-arm64) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/cross-python_osx-arm64.svg)](https://anaconda.org/conda-forge/cross-python_osx-arm64) |
 
-Installing cross-python_linux-aarch64
-=====================================
+Installing cross-python_osx-arm64
+=================================
 
-Installing `cross-python_linux-aarch64` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `cross-python_osx-arm64` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `cross-python_linux-64, cross-python_linux-aarch64, cross-python_linux-ppc64le, cross-python_osx-64, cross-python_osx-arm64` can be installed with:
+Once the `conda-forge` channel has been enabled, `cross-python_osx-64, cross-python_osx-arm64` can be installed with:
 
 ```
-conda install cross-python_linux-64 cross-python_linux-aarch64 cross-python_linux-ppc64le cross-python_osx-64 cross-python_osx-arm64
+conda install cross-python_osx-64 cross-python_osx-arm64
 ```
 
-It is possible to list all of the versions of `cross-python_linux-64` available on your platform with:
+It is possible to list all of the versions of `cross-python_osx-64` available on your platform with:
 
 ```
-conda search cross-python_linux-64 --channel conda-forge
+conda search cross-python_osx-64 --channel conda-forge
 ```
 
 
@@ -295,17 +299,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating cross-python_linux-aarch64-feedstock
-=============================================
+Updating cross-python_osx-arm64-feedstock
+=========================================
 
-If you would like to improve the cross-python_linux-aarch64 recipe or build a new
+If you would like to improve the cross-python_osx-arm64 recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/cross-python_linux-aarch64-feedstock are
+Note that all branches in the conda-forge/cross-python_osx-arm64-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/build-locally.py
+++ b/build-locally.py
@@ -13,6 +13,7 @@ import platform
 def setup_environment(ns):
     os.environ["CONFIG"] = ns.config
     os.environ["UPLOAD_PACKAGES"] = "False"
+    os.environ["IS_PR_BUILD"] = "True"
     if ns.debug:
         os.environ["BUILD_WITH_CONDA_DEBUG"] = "1"
         if ns.output_id:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ build:
   number: {{ build_number }}
   string: {{ build_number }}_{{ py_impl }}
   skip: True  # [win]
-{% if (cross_target_platform == "osx-arm64" and not (version == "3.8" or version == "3.9")) or (cross_target_platform == target_platform) %}
+{% if (cross_target_platform == "osx-arm64" and version not in ("3.8", "3.9", "3.10")) or (cross_target_platform == target_platform) %}
   skip: True
 {% endif %}
   run_exports:


### PR DESCRIPTION
Not increasing the build number because this doesn't change anything about the build itself, just unblocks 3.10 for osx-arm.

Needed by https://github.com/conda-forge/tbb-feedstock/pull/93