### PR TITLE
Use os.path.realpath from python

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set build_number = 24 %}
+{% set build_number = 25 %}
 {% if cross_target_platform is undefined %}
 {% set cross_target_platform = "linux-64" %}
 {% endif %}


### PR DESCRIPTION
Fixes the issue described in https://github.com/conda-forge/cross-python-feedstock/pull/44#discussion_r905287551

I don't particularly like this solution but it seems to keep the correct structure and we rely on `$BUILD_PREFIX/bin/python` in other places so it's not adding any dependencies at least:

```bash
(/home/conda/feedstock_root/build_artifacts/debug_1656013743303/_build_env) [conda@3ab515868fc7 work]$ ls --color=auto -lai /home/conda/feedstock_root/build_artifacts/debug_1656013743303/_h_env/bin/{python*,pypy3} /home/conda/feedstock_root/build_artifacts/pkg_cache/pypy3.8-7.3.9-hfb6fae5_1/bin/pypy3
3682162 -rwxr-xr-x 1 conda conda 1866 Jun 23 20:16 /home/conda/feedstock_root/build_artifacts/debug_1656013743303/_h_env/bin/pypy3
3682119 lrwxrwxrwx 1 conda conda    5 Jun 23 19:51 /home/conda/feedstock_root/build_artifacts/debug_1656013743303/_h_env/bin/python -> pypy3
3682098 lrwxrwxrwx 1 conda conda    5 Jun 23 19:51 /home/conda/feedstock_root/build_artifacts/debug_1656013743303/_h_env/bin/python3 -> pypy3
3682122 lrwxrwxrwx 1 conda conda    5 Jun 23 19:51 /home/conda/feedstock_root/build_artifacts/debug_1656013743303/_h_env/bin/python3.8 -> pypy3
3849391 -rwxrwxr-x 1 conda conda 6192 Apr  8 08:35 /home/conda/feedstock_root/build_artifacts/pkg_cache/pypy3.8-7.3.9-hfb6fae5_1/bin/pypy3
```

@isuruf Any thoughts?