### PR TITLE
Add build prefix's lib-dynload directory to PYTHONPATH

### DIFF
--- a/recipe/activate-cross-python.sh
+++ b/recipe/activate-cross-python.sh
@@ -70,8 +70,7 @@ if [[ "${CONDA_BUILD:-0}" == "1" && "${CONDA_BUILD_STATE}" != "TEST" ]]; then
     fi
     rm -rf $BUILD_PREFIX/venv/lib/python$PY_VER/site-packages
     ln -s $BUILD_PREFIX/lib/python$PY_VER/site-packages $BUILD_PREFIX/venv/lib/python$PY_VER/site-packages
-    ln -s $BUILD_PREFIX/lib/python$PY_VER/lib-dynload $BUILD_PREFIX/venv/lib/python$PY_VER/lib-dynload
-    sed -i.bak "s@$BUILD_PREFIX/venv/lib@$BUILD_PREFIX/venv/lib', '$BUILD_PREFIX/venv/lib/python$PY_VER/lib-dynload', '$BUILD_PREFIX/venv/lib/python$PY_VER/site-packages@g" $python_real_path
+    sed -i.bak "s@$BUILD_PREFIX/venv/lib@$BUILD_PREFIX/venv/lib', '$BUILD_PREFIX/lib/python$PY_VER/lib-dynload', '$BUILD_PREFIX/venv/lib/python$PY_VER/site-packages@g" $python_real_path
     rm -f ${python_real_path}.bak
 
     unset python_real_path

--- a/recipe/activate-cross-python.sh
+++ b/recipe/activate-cross-python.sh
@@ -70,7 +70,8 @@ if [[ "${CONDA_BUILD:-0}" == "1" && "${CONDA_BUILD_STATE}" != "TEST" ]]; then
     fi
     rm -rf $BUILD_PREFIX/venv/lib/python$PY_VER/site-packages
     ln -s $BUILD_PREFIX/lib/python$PY_VER/site-packages $BUILD_PREFIX/venv/lib/python$PY_VER/site-packages
-    sed -i.bak "s@$BUILD_PREFIX/venv/lib@$BUILD_PREFIX/venv/lib', '$BUILD_PREFIX/venv/lib/python$PY_VER/site-packages@g" $python_real_path
+    ln -s $BUILD_PREFIX/lib/python$PY_VER/lib-dynload $BUILD_PREFIX/venv/lib/python$PY_VER/lib-dynload
+    sed -i.bak "s@$BUILD_PREFIX/venv/lib@$BUILD_PREFIX/venv/lib', '$BUILD_PREFIX/venv/lib/python$PY_VER/lib-dynload', '$BUILD_PREFIX/venv/lib/python$PY_VER/site-packages@g" $python_real_path
     rm -f ${python_real_path}.bak
 
     unset python_real_path

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set build_number = 30 %}
+{% set build_number = 31 %}
 {% if cross_target_platform is undefined %}
 {% set cross_target_platform = "linux-64" %}
 {% endif %}


### PR DESCRIPTION
I think this fixes the issue seen in https://github.com/conda-forge/crossenv-feedstock/pull/34.

The frozen `site` module is still causing differences, though I'm not sure if it's going to cause problems:

```
$ /home/cburr/miniconda3/conda-bld/pytest_1666698751133/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_plac/bin/python3.11 -X frozen_modules=on -m site
sys.path = [
    '/home/cburr/miniconda3/conda-bld/pytest_1666698751133/work',
    '/home/cburr/miniconda3/conda-bld/pytest_1666698751133/_build_env/venv/lib',
    '/home/cburr/miniconda3/conda-bld/pytest_1666698751133/_build_env/venv/lib/python3.11/lib-dynload',
    '/home/cburr/miniconda3/conda-bld/pytest_1666698751133/_build_env/venv/lib/python3.11/site-packages',
    '/home/cburr/miniconda3/conda-bld/pytest_1666698751133/_build_env/lib/python3.11',
    '/home/cburr/miniconda3/conda-bld/pytest_1666698751133/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_plac/lib/python311.zip',
    '/home/cburr/miniconda3/conda-bld/pytest_1666698751133/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_plac/lib/python3.11',
    '/home/cburr/miniconda3/conda-bld/pytest_1666698751133/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_plac/lib/python3.11/lib-dynload',
    '/home/cburr/miniconda3/conda-bld/pytest_1666698751133/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_plac/lib/python3.11/site-packages',
]
USER_BASE: '/home/cburr/.local' (exists)
USER_SITE: '/home/cburr/.local/lib/python3.11/site-packages' (doesn't exist)
ENABLE_USER_SITE: False
$
$
$ /home/cburr/miniconda3/conda-bld/pytest_1666698751133/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_plac/bin/python3.11 -X frozen_modules=off -m site
sys.path = [
    '/home/cburr/miniconda3/conda-bld/pytest_1666698751133/work',
    '/home/cburr/miniconda3/conda-bld/pytest_1666698751133/_build_env/venv/lib/python3.11/lib-dynload',
    '/home/cburr/miniconda3/conda-bld/pytest_1666698751133/_build_env/venv/lib/python3.11/site-packages',
    '/home/cburr/miniconda3/conda-bld/pytest_1666698751133/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_plac/lib/python311.zip',
    '/home/cburr/miniconda3/conda-bld/pytest_1666698751133/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_plac/lib/python3.11',
    '/home/cburr/miniconda3/conda-bld/pytest_1666698751133/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_plac/lib/python3.11/lib-dynload',
    '/home/cburr/miniconda3/conda-bld/pytest_1666698751133/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_plac/lib/python3.11/site-packages',
]
USER_BASE: '/home/cburr/.local' (exists)
USER_SITE: '/home/cburr/.local/lib/python3.11/site-packages' (doesn't exist)
ENABLE_USER_SITE: False
```