### PR TITLE
workaround for pypy which does not honor PYTHONHOME env var

### DIFF
--- a/recipe/activate-cross-python.sh
+++ b/recipe/activate-cross-python.sh
@@ -39,7 +39,12 @@ if [[ "${CONDA_BUILD:-0}" == "1" && "${CONDA_BUILD_STATE}" != "TEST" ]]; then
     python_real_path=$($BUILD_PREFIX/bin/python -c "import os; print(os.path.realpath('$PREFIX/bin/python'))")
     cp $BUILD_PREFIX/venv/cross/bin/python $BUILD_PREFIX/venv/bin/cross-python
     rm $python_real_path
-    cp $BUILD_PREFIX/bin/cross_python_shim $python_real_path
+    if [ -d "$PREFIX/lib/pypy$PY_VER" ]; then
+	# TODO: Remove this when pypy supports PYTHONHOME env variable
+        cp $BUILD_PREFIX/venv/cross/bin/python $python_real_path
+    else
+        cp $BUILD_PREFIX/bin/cross_python_shim $python_real_path
+    fi
 
     # don't set LIBRARY_PATH
     # See https://github.com/conda-forge/matplotlib-feedstock/pull/309#issuecomment-972213735

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set build_number = 34 %}
+{% set build_number = 35 %}
 {% if cross_target_platform is undefined %}
 {% set cross_target_platform = "linux-64" %}
 {% endif %}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Closes #67 